### PR TITLE
PROJ22-304 Only compare to last month of surveys due to performance i…

### DIFF
--- a/sql/Survey_factResponse.sql
+++ b/sql/Survey_factResponse.sql
@@ -26,5 +26,5 @@ INNER JOIN custom.Survey_dimRespondent dr
     ON kpr.participant_id = dr.RespondentKey COLLATE Latin1_General_CS_AS
     AND dsurv.SurveyKey = dr.SurveyKey
 LEFT JOIN existingResponses er
-    ON er.RespondentKey COLLATE Latin1_General_CS_AS + STR(er.QuestionKey) = dr.RespondentKey + STR(dq.QuestionKey)
+    ON er.RespondentKey COLLATE Latin1_General_CS_AS + STR(er.QuestionKey) = dr.RespondentKey COLLATE Latin1_General_CS_AS + STR(dq.QuestionKey)
 WHERE er.QuestionKey IS NULL


### PR DESCRIPTION
…ssues

I'm altering the logic that prevents duplicates from being inserted into the fact.

For Kelvin, the data volume is large and performance became an issue, so when generating the new fact records and comparing them to existing ones to prevent dupes, I'm only compare the last month of data. Previously, we were comparing to all fact records. This one month time window should be plenty because Kelvin is running on a weekly basis.

I'll keep this PR open and manually run the connector on Tuesday to confirm it works well for this year's first survey responses.