### PR TITLE
PROJ22-947 Update fact insertion logic due to timeout issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,11 @@ $ docker run --rm -it kelvin
 # Useful for printing files to local directory
 $ docker run --rm -it -v ${PWD}:/code/ kelvin
 ```
+
+## Troubleshooting and maintenance
+
+### Scheduling
+The job should be scheduled to run once a week because Kelvin Pulse surveys do not close more frequently than weekly. If this frequency changes, then the time window filter in `Survey_factResponse.sql` should also be updated.
+
+### Re-running
+We are not comparing to existing records due to performance challenges. If the job needs to be rerun, you should delete any survey dim and fact data associated with the last week - do this directly in the database. If you don't do this, then there will be duplicates.

--- a/sql/Survey_factResponse.sql
+++ b/sql/Survey_factResponse.sql
@@ -1,13 +1,3 @@
-WITH existingResponses AS (
-    SELECT fr.*
-    FROM custom.Survey_factResponse fr
-    INNER JOIN custom.Survey_dimQuestion q
-        ON q.QuestionKey = fr.QuestionKey
-    INNER JOIN custom.Survey_dimSurvey s
-        ON s.SurveyKey = q.SurveyKey
-    WHERE s.WindowEnd > DATEADD(month, -1, GETDATE()) -- only compare to last month of surveys due to performance issues
-)
-
 SELECT
     dr.RespondentKey AS RespondentKey
     , dq.QuestionKey AS QuestionKey
@@ -18,13 +8,11 @@ INNER JOIN custom.Survey_dimSurvey dsurv
     AND dsurv.Category = 'Pulse'
     AND dsurv.System = 'Kelvin'
     AND kpr.pulse_name = dsurv.Name
-    AND dsurv.WindowEnd > DATEADD(month, -1, GETDATE()) -- only compare to last month of surveys due to performance issues
 INNER JOIN custom.Survey_dimQuestion dq
     ON kpr.responses_stem = dq.Question
     AND dsurv.SurveyKey = dq.SurveyKey
 INNER JOIN custom.Survey_dimRespondent dr
     ON kpr.participant_id = dr.RespondentKey COLLATE Latin1_General_CS_AS
     AND dsurv.SurveyKey = dr.SurveyKey
-LEFT JOIN existingResponses er
-    ON er.RespondentKey COLLATE Latin1_General_CS_AS + STR(er.QuestionKey) = dr.RespondentKey COLLATE Latin1_General_CS_AS + STR(dq.QuestionKey)
-WHERE er.QuestionKey IS NULL
+WHERE 1=1
+    AND dsurv.WindowEnd > DATEADD(week, -1, GETDATE()) -- only get surveys that ended in the last week, assuming the connector runs weekly.


### PR DESCRIPTION
I'm changing the logic of the parser that pulls raw Kelvin data into the survey model because we're persistently running into performance issues that cause the job to fail.

Summary of the change: When deciding what data to insert, we're no longer comparing to existing records in the fact to ensure no duplicates. Instead, I'm inserting new records based on any surveys that closed in the last week.

Implications: The downside of this change is that, if the Kelvin connector needs to be re-run within a week of the last time it ran, it will not automatically avoid inserting duplicates. Instead, there is an added manual step, where you'll need to go into the database and delete existing records dim/fact from the last week. I've added this documentation to the README, but please let me know if it's unclear.

Note for future enhancement: I think this is the right approach in the short term, and in order to make this more "bulletproof" in the future, we may need to make some changes to our survey model so that respondentKey is unique and can be indexed (right now there are dupes across surveys). I'm hoping that can help with performance of the left join to existing responses.